### PR TITLE
Keep passwordless lookup country-based

### DIFF
--- a/drfpasswordless/serializers.py
+++ b/drfpasswordless/serializers.py
@@ -87,8 +87,8 @@ class AbstractBaseAliasAuthenticationSerializer(serializers.Serializer):
         # We know this is there as it's marked required in the serializer field (email or mobile) below
         alias = attrs.get(self.alias_type)
         
-        # Since phone number / email are unique by access scope.
-        # Keep country in the API for compatibility, and map it internally.
+        # Keep country in the API for compatibility. Existing-user lookups must
+        # stay country-based while access_scope is only populated for new users.
         country, access_scope = get_country_and_access_scope(attrs.get('country'))
 
         if alias:
@@ -99,28 +99,33 @@ class AbstractBaseAliasAuthenticationSerializer(serializers.Serializer):
                 # We can optionally allow registration of more user model fields at the same time, these are
                 # whitelisted in the settings variable and filtered here before passed to get_or_create
 
+                for reqkey in api_settings.PASSWORDLESS_USER_CREATION_FIELDS_REQ:
+                    if attrs.get(reqkey, None) is None:
+                        raise serializers.ValidationError('Field %s missing while creating new user' % reqkey)
+
                 if country == 'se':
                     default_digilets = api_settings.PASSWORDLESS_SE_NEW_USER_DIGILETS 
                 else:
                     default_digilets = api_settings.PASSWORDLESS_FI_NEW_USER_DIGILETS 
 
-                new_user_attrs = { self.alias_type: alias, 'country': country,
-                                   'access_scope': access_scope, 'digilets': default_digilets }
+                user_lookup_attrs = { self.alias_type: alias, 'country': country }
+                filtered_creation_attrs = {
+                    fkey: attrs[fkey]
+                    for fkey in api_settings.PASSWORDLESS_USER_CREATION_FIELDS
+                    if fkey not in user_lookup_attrs and attrs.get(fkey, None) is not None
+                }
+                new_user_defaults = {
+                    'access_scope': access_scope,
+                    'digilets': default_digilets,
+                    **filtered_creation_attrs,
+                }
+                # Use alias and country for existence checks so users without access_scope populated are still detected.
+                # access_scope and the other defaults are only applied when a new user is created.
+                if UserModel.objects.filter(**user_lookup_attrs).exists():
+                    raise serializers.ValidationError('User email or mobile already taken')
 
-                for fkey in api_settings.PASSWORDLESS_USER_CREATION_FIELDS:
-                    val = attrs.get(fkey, None)
-                    if val is not None:
-                        new_user_attrs[fkey] = val
-                for reqkey in api_settings.PASSWORDLESS_USER_CREATION_FIELDS_REQ:
-                    if not reqkey in new_user_attrs:
-                        raise serializers.ValidationError('Field %s missing while creating new user' % reqkey)
-                # The get_or_create is to make the register API call idempotent, so if it's repeated, you get the same result.
-                # If we use only create here, the first call would create the user and the second call would return the validationerror.
-                #
-                # We get db integrity exceptions if we try to create a new user with the same email and/or mobile, even if
-                # the other fields are different, which is good.
                 try:
-                    user, created = UserModel.objects.get_or_create(**new_user_attrs)
+                    user = UserModel.objects.create(**user_lookup_attrs, **new_user_defaults)
                 except IntegrityError:
                     raise serializers.ValidationError('User email or mobile already taken')
             else:
@@ -128,7 +133,7 @@ class AbstractBaseAliasAuthenticationSerializer(serializers.Serializer):
                 try:
                     # TODO: allow updating the user with the new attrs at this point, if the user is not validated on either of the
                     # email or phone yet but is still existing in the database.
-                    user = UserModel.objects.get(**{self.alias_type: alias, 'access_scope': access_scope})
+                    user = UserModel.objects.get(**{self.alias_type: alias, 'country': country})
                 except UserModel.DoesNotExist:
                     user = None
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -15,7 +15,7 @@ class CustomUser(AbstractBaseUser):
     mobile = models.CharField(validators=[phone_regex], max_length=15, blank=True, null=True)
     mobile_verified = models.BooleanField(default=False)
     country = models.CharField(default='se', max_length=2)
-    access_scope = models.CharField(default='glimra', max_length=32)
+    access_scope = models.CharField(default='glimra', max_length=32, null=True)
     digilets = models.IntegerField(default=0)
     is_active = models.BooleanField(default=True)
     is_demo = models.BooleanField(default=False)

--- a/tests/models.py
+++ b/tests/models.py
@@ -44,6 +44,6 @@ class CustomUser(AbstractBaseUser):
     class Meta:
         app_label = 'tests'
         unique_together = (
-            ('email', 'access_scope'),
-            ('mobile', 'access_scope'),
+            ('email', 'country'),
+            ('mobile', 'country'),
         )

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -419,6 +419,32 @@ class MobileSignUpCallbackTokenTests(APITestCase):
         # Verify a token exists for the user
         self.assertEqual(CallbackToken.objects.filter(user=user, is_active=True).exists(), 1)
 
+    def test_same_mobile_can_signup_in_different_countries(self):
+        mobile = '+15551234567'
+        api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER_FI = '+358500000000'
+
+        se_response = self.client.post(self.url, {
+            'mobile': mobile,
+            'country': 'se',
+            'create': True,
+        })
+        fi_response = self.client.post(self.url, {
+            'mobile': mobile,
+            'country': 'fi',
+            'create': True,
+        })
+
+        self.assertEqual(se_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(fi_response.status_code, status.HTTP_200_OK)
+
+        se_user = User.objects.get(**{self.mobile_field_name: mobile, 'country': 'se'})
+        fi_user = User.objects.get(**{self.mobile_field_name: mobile, 'country': 'fi'})
+        self.assertEqual(se_user.access_scope, 'glimra')
+        self.assertEqual(fi_user.access_scope, 'juhlapesu')
+        self.assertEqual(User.objects.filter(**{self.mobile_field_name: mobile}).count(), 2)
+        self.assertEqual(CallbackToken.objects.filter(user=se_user, is_active=True).count(), 1)
+        self.assertEqual(CallbackToken.objects.filter(user=fi_user, is_active=True).count(), 1)
+
     def test_second_mobile_signup_request_is_rejected(self):
         mobile = '+15551234567'
         data = {'mobile': mobile, 'create': True}

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -43,6 +43,22 @@ class EmailSignUpCallbackTokenTests(APITestCase):
         # Verify a token exists for the user
         self.assertEqual(CallbackToken.objects.filter(user=user, is_active=True).exists(), 1)
 
+    def test_second_email_signup_request_is_rejected(self):
+        email = 'aaron@example.com'
+        data = {'email': email, 'create': True}
+
+        first_response = self.client.post(self.url, data)
+        self.assertEqual(first_response.status_code, status.HTTP_200_OK)
+
+        user = User.objects.get(**{self.email_field_name: email})
+        CallbackToken.objects.filter(user=user).delete()
+
+        second_response = self.client.post(self.url, data)
+
+        self.assertEqual(second_response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(User.objects.filter(**{self.email_field_name: email}).count(), 1)
+        self.assertEqual(CallbackToken.objects.filter(user=user, is_active=True).count(), 0)
+
     def test_email_signup_disabled(self):
         api_settings.PASSWORDLESS_REGISTER_NEW_USERS = False
 
@@ -108,6 +124,42 @@ class AccessScopeMappingTests(APITestCase):
         self.assertEqual(user.country, 'fi')
         self.assertEqual(user.access_scope, 'juhlapesu')
 
+    def test_existing_email_with_null_access_scope_is_found_by_country(self):
+        email = 'aaron@example.com'
+        existing_user = User.objects.create(email=email, country='fi', access_scope=None)
+
+        serializer = EmailAuthSerializer(data={'email': email, 'country': 'fi'})
+
+        self.assertEqual(serializer.is_valid(), True)
+        self.assertEqual(serializer.validated_data['user'], existing_user)
+        self.assertIsNone(serializer.validated_data['user'].access_scope)
+        self.assertEqual(serializer.validated_data['access_scope'], 'juhlapesu')
+
+    def test_existing_mobile_with_null_access_scope_is_found_by_country(self):
+        mobile = '+15551234567'
+        existing_user = User.objects.create(mobile=mobile, country='se', access_scope=None)
+
+        serializer = MobileAuthSerializer(data={'mobile': mobile, 'country': 'se'})
+
+        self.assertEqual(serializer.is_valid(), True)
+        self.assertEqual(serializer.validated_data['user'], existing_user)
+        self.assertIsNone(serializer.validated_data['user'].access_scope)
+        self.assertEqual(serializer.validated_data['access_scope'], 'glimra')
+
+    def test_create_true_rejects_existing_user_with_null_access_scope(self):
+        email = 'aaron@example.com'
+        User.objects.create(email=email, country='se', access_scope=None)
+
+        serializer = EmailAuthSerializer(data={
+            'email': email,
+            'country': 'se',
+            'create': True,
+        })
+
+        self.assertEqual(serializer.is_valid(), False)
+        self.assertIn('non_field_errors', serializer.errors)
+        self.assertEqual(User.objects.count(), 1)
+
     def test_unsupported_country_is_rejected(self):
         serializer = EmailAuthSerializer(data={
             'email': 'aaron@example.com',
@@ -130,7 +182,7 @@ class AccessScopeMappingTests(APITestCase):
         self.assertEqual(se_serializer.validated_data['user'], glimra_user)
         self.assertEqual(fi_serializer.validated_data['user'], juhlapesu_user)
 
-    def test_existing_email_fails_registration_in_same_access_scope(self):
+    def test_existing_email_registration_is_rejected_in_same_country(self):
         email = 'aaron@example.com'
         User.objects.create(email=email, country='se', access_scope='glimra', digilets=1)
 
@@ -142,6 +194,7 @@ class AccessScopeMappingTests(APITestCase):
 
         self.assertEqual(serializer.is_valid(), False)
         self.assertIn('non_field_errors', serializer.errors)
+        self.assertEqual(User.objects.count(), 1)
 
     def test_same_mobile_can_exist_in_different_access_scopes(self):
         mobile = '+15551234567'
@@ -156,7 +209,7 @@ class AccessScopeMappingTests(APITestCase):
         self.assertEqual(se_serializer.validated_data['user'], glimra_user)
         self.assertEqual(fi_serializer.validated_data['user'], juhlapesu_user)
 
-    def test_existing_mobile_fails_registration_in_same_access_scope(self):
+    def test_existing_mobile_registration_is_rejected_in_same_country(self):
         mobile = '+15551234567'
         User.objects.create(mobile=mobile, country='se', access_scope='glimra', digilets=1)
 
@@ -168,6 +221,85 @@ class AccessScopeMappingTests(APITestCase):
 
         self.assertEqual(serializer.is_valid(), False)
         self.assertIn('non_field_errors', serializer.errors)
+        self.assertEqual(User.objects.count(), 1)
+
+
+class NullAccessScopeLoginCallbackTokenTests(APITestCase):
+
+    def tearDown(self):
+        api_settings.PASSWORDLESS_TEST_SUPPRESSION = DEFAULTS['PASSWORDLESS_TEST_SUPPRESSION']
+        api_settings.PASSWORDLESS_AUTH_TYPES = DEFAULTS['PASSWORDLESS_AUTH_TYPES']
+        api_settings.PASSWORDLESS_EMAIL_NOREPLY_ADDRESS = DEFAULTS['PASSWORDLESS_EMAIL_NOREPLY_ADDRESS']
+        api_settings.PASSWORDLESS_EMAIL_NOREPLY_ADDRESS_FI = DEFAULTS['PASSWORDLESS_EMAIL_NOREPLY_ADDRESS_FI']
+        api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER = DEFAULTS['PASSWORDLESS_MOBILE_NOREPLY_NUMBER']
+        api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER_FI = DEFAULTS['PASSWORDLESS_MOBILE_NOREPLY_NUMBER_FI']
+
+    def test_existing_se_email_with_null_access_scope_can_request_token(self):
+        api_settings.PASSWORDLESS_AUTH_TYPES = ['EMAIL']
+        api_settings.PASSWORDLESS_EMAIL_NOREPLY_ADDRESS = 'noreply@example.com'
+        user = User.objects.create(email='se@example.com', country='se', access_scope=None)
+
+        response = self.client.post('/auth/email/', {'email': user.email, 'country': 'se'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(CallbackToken.objects.filter(user=user, is_active=True).count(), 1)
+        user.refresh_from_db()
+        self.assertIsNone(user.access_scope)
+
+    def test_existing_fi_email_with_null_access_scope_can_request_token(self):
+        api_settings.PASSWORDLESS_AUTH_TYPES = ['EMAIL']
+        api_settings.PASSWORDLESS_EMAIL_NOREPLY_ADDRESS = 'noreply@example.com'
+        api_settings.PASSWORDLESS_EMAIL_NOREPLY_ADDRESS_FI = 'noreply-fi@example.com'
+        user = User.objects.create(email='fi@example.com', country='fi', access_scope=None)
+
+        response = self.client.post('/auth/email/', {'email': user.email, 'country': 'fi'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(CallbackToken.objects.filter(user=user, is_active=True).count(), 1)
+        user.refresh_from_db()
+        self.assertIsNone(user.access_scope)
+
+    def test_existing_se_mobile_with_null_access_scope_can_request_token(self):
+        api_settings.PASSWORDLESS_TEST_SUPPRESSION = True
+        api_settings.PASSWORDLESS_AUTH_TYPES = ['MOBILE']
+        api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER = '+15550000000'
+        user = User.objects.create(mobile='+15551234567', country='se', access_scope=None)
+
+        response = self.client.post('/auth/mobile/', {'mobile': user.mobile, 'country': 'se'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(CallbackToken.objects.filter(user=user, is_active=True).count(), 1)
+        user.refresh_from_db()
+        self.assertIsNone(user.access_scope)
+
+    def test_existing_fi_mobile_with_null_access_scope_can_request_token(self):
+        api_settings.PASSWORDLESS_TEST_SUPPRESSION = True
+        api_settings.PASSWORDLESS_AUTH_TYPES = ['MOBILE']
+        api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER_FI = '+358500000000'
+        user = User.objects.create(mobile='+15557654321', country='fi', access_scope=None)
+
+        response = self.client.post('/auth/mobile/', {'mobile': user.mobile, 'country': 'fi'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(CallbackToken.objects.filter(user=user, is_active=True).count(), 1)
+        user.refresh_from_db()
+        self.assertIsNone(user.access_scope)
+
+    def test_existing_mobile_create_request_is_rejected_without_sending_token(self):
+        api_settings.PASSWORDLESS_TEST_SUPPRESSION = True
+        api_settings.PASSWORDLESS_AUTH_TYPES = ['MOBILE']
+        api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER = '+15550000000'
+        user = User.objects.create(mobile='+15559876543', country='se', access_scope=None)
+
+        response = self.client.post('/auth/mobile/', {
+            'mobile': user.mobile,
+            'country': 'se',
+            'create': True,
+        })
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(CallbackToken.objects.filter(user=user, is_active=True).count(), 0)
+        self.assertEqual(User.objects.count(), 1)
 
 
 class EmailLoginCallbackTokenTests(APITestCase):
@@ -286,6 +418,22 @@ class MobileSignUpCallbackTokenTests(APITestCase):
 
         # Verify a token exists for the user
         self.assertEqual(CallbackToken.objects.filter(user=user, is_active=True).exists(), 1)
+
+    def test_second_mobile_signup_request_is_rejected(self):
+        mobile = '+15551234567'
+        data = {'mobile': mobile, 'create': True}
+
+        first_response = self.client.post(self.url, data)
+        self.assertEqual(first_response.status_code, status.HTTP_200_OK)
+
+        user = User.objects.get(**{self.mobile_field_name: mobile})
+        CallbackToken.objects.filter(user=user).delete()
+
+        second_response = self.client.post(self.url, data)
+
+        self.assertEqual(second_response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(User.objects.filter(**{self.mobile_field_name: mobile}).count(), 1)
+        self.assertEqual(CallbackToken.objects.filter(user=user, is_active=True).count(), 0)
 
     def test_mobile_signup_disabled(self):
         api_settings.PASSWORDLESS_REGISTER_NEW_USERS = False


### PR DESCRIPTION
Just populate access_scope for user creation, not for lookup.

Backfilling access_scope on users will not be done as part of the migration but at runtime using a script.

As such the drfpasswordless fork needs to handle that access_scope is missing on users during a transition period, and this PR updates the fork to keep using mobile/email + country to query for users.

Once all users have been assigned an access_scope the lib can be changed back to query using mobile/email + access_scope