### PR TITLE
GLI-3931 - Segment users by access scope and accept access_scope as an API request field

### DIFF
--- a/drfpasswordless/serializers.py
+++ b/drfpasswordless/serializers.py
@@ -16,23 +16,44 @@ from glimra.base.fields import PhoneNumberSerializerField
 logger = logging.getLogger(__name__)
 UserModel = get_user_model()
 
+ACCESS_SCOPE_TO_COUNTRY = {
+    'glimra': 'se',
+    'juhlapesu': 'fi',
+}
 COUNTRY_TO_ACCESS_SCOPE = {
-    'se': 'glimra',
-    'fi': 'juhlapesu',
+    country: access_scope for access_scope, country in ACCESS_SCOPE_TO_COUNTRY.items()
 }
 DEFAULT_COUNTRY = 'se'
 
 
-def get_country_and_access_scope(country):
-    country = country or DEFAULT_COUNTRY
-    country = country.lower()
+def get_country_and_access_scope(country=None, access_scope=None):
+    country = country.lower() if country else None
+    access_scope = access_scope.lower() if access_scope else None
 
-    try:
-        return country, COUNTRY_TO_ACCESS_SCOPE[country]
-    except KeyError:
+    if access_scope and access_scope not in ACCESS_SCOPE_TO_COUNTRY:
+        raise serializers.ValidationError({
+            'access_scope': _('Unsupported access scope.')
+        })
+
+    if country and country not in COUNTRY_TO_ACCESS_SCOPE:
         raise serializers.ValidationError({
             'country': _('Unsupported country.')
         })
+
+    if country and access_scope:
+        expected_country = ACCESS_SCOPE_TO_COUNTRY[access_scope]
+        if country != expected_country:
+            raise serializers.ValidationError({
+                'country': _('Country does not match access scope.')
+            })
+
+    if access_scope:
+        country = ACCESS_SCOPE_TO_COUNTRY[access_scope]
+    else:
+        country = country or DEFAULT_COUNTRY
+        access_scope = COUNTRY_TO_ACCESS_SCOPE[country]
+
+    return country, access_scope
 
 
 class TokenField(serializers.CharField):
@@ -76,6 +97,9 @@ class AbstractBaseAliasAuthenticationSerializer(serializers.Serializer):
     # The country of which the user belongs to
     country = serializers.CharField(required=False)
 
+    # The access scope of which the user belongs to
+    access_scope = serializers.CharField(required=False)
+
     @property
     def alias_type(self):
         # The alias type, either email or mobile
@@ -89,8 +113,11 @@ class AbstractBaseAliasAuthenticationSerializer(serializers.Serializer):
         alias = attrs.get(self.alias_type)
 
         # Since phone number / email are unique by access scope.
-        # Keep country in the API for compatibility, and map it internally.
-        country, access_scope = get_country_and_access_scope(attrs.get('country'))
+        # Keep country in the API for compatibility, and allow clients to pass access_scope directly.
+        country, access_scope = get_country_and_access_scope(
+            attrs.get('country'),
+            attrs.get('access_scope')
+        )
 
         if alias:
             # Create or authenticate a user and return it. The client has to explicitly request creation by 'create',

--- a/drfpasswordless/serializers.py
+++ b/drfpasswordless/serializers.py
@@ -87,9 +87,9 @@ class AbstractBaseAliasAuthenticationSerializer(serializers.Serializer):
     def validate(self, attrs):
         # We know this is there as it's marked required in the serializer field (email or mobile) below
         alias = attrs.get(self.alias_type)
-        
-        # Keep country in the API for compatibility. Existing-user lookups must
-        # stay country-based while access_scope is only populated for new users.
+
+        # Since phone number / email are unique by access scope.
+        # Keep country in the API for compatibility, and map it internally.
         country, access_scope = get_country_and_access_scope(attrs.get('country'))
 
         if alias:
@@ -109,21 +109,22 @@ class AbstractBaseAliasAuthenticationSerializer(serializers.Serializer):
                 else:
                     default_digilets = api_settings.PASSWORDLESS_FI_NEW_USER_DIGILETS 
 
-                user_lookup_attrs = { self.alias_type: alias, 'country': country }
-                filtered_creation_attrs = {
-                    fkey: attrs[fkey]
-                    for fkey in api_settings.PASSWORDLESS_USER_CREATION_FIELDS
-                    if fkey not in user_lookup_attrs and attrs.get(fkey, None) is not None
-                }
+                user_lookup_attrs = {self.alias_type: alias, 'access_scope': access_scope}
+                # Country is handled above so we always store the normalized value,
+                # not the raw request value from PASSWORDLESS_USER_CREATION_FIELDS.
+                filtered_creation_attrs = {}
+                for fkey in api_settings.PASSWORDLESS_USER_CREATION_FIELDS:
+                    if fkey in user_lookup_attrs or fkey == 'country':
+                        continue
+                    if attrs.get(fkey, None) is not None:
+                        filtered_creation_attrs[fkey] = attrs[fkey]
                 new_user_defaults = {
-                    'access_scope': access_scope,
+                    'country': country,
                     'digilets': default_digilets,
                     **filtered_creation_attrs,
                 }
                 try:
                     with transaction.atomic():
-                        # Use alias and country for existence checks so users without access_scope populated are still detected.
-                        # access_scope and the other defaults are only applied when a new user is created.
                         if UserModel.objects.filter(**user_lookup_attrs).exists():
                             raise serializers.ValidationError('User email or mobile already taken')
 
@@ -135,7 +136,7 @@ class AbstractBaseAliasAuthenticationSerializer(serializers.Serializer):
                 try:
                     # TODO: allow updating the user with the new attrs at this point, if the user is not validated on either of the
                     # email or phone yet but is still existing in the database.
-                    user = UserModel.objects.get(**{self.alias_type: alias, 'country': country})
+                    user = UserModel.objects.get(**{self.alias_type: alias, 'access_scope': access_scope})
                 except UserModel.DoesNotExist:
                     user = None
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -15,7 +15,7 @@ class CustomUser(AbstractBaseUser):
     mobile = models.CharField(validators=[phone_regex], max_length=15, blank=True, null=True)
     mobile_verified = models.BooleanField(default=False)
     country = models.CharField(default='se', max_length=2)
-    access_scope = models.CharField(default='glimra', max_length=32, null=True)
+    access_scope = models.CharField(default='glimra', max_length=32)
     digilets = models.IntegerField(default=0)
     is_active = models.BooleanField(default=True)
     is_demo = models.BooleanField(default=False)
@@ -44,6 +44,6 @@ class CustomUser(AbstractBaseUser):
     class Meta:
         app_label = 'tests'
         unique_together = (
-            ('email', 'country'),
-            ('mobile', 'country'),
+            ('email', 'access_scope'),
+            ('mobile', 'access_scope'),
         )

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -87,7 +87,7 @@ class EmailSignUpCallbackTokenTests(APITestCase):
 
 class AccessScopeMappingTests(APITestCase):
 
-    def test_omitted_country_maps_to_glimra(self):
+    def test_omitted_country_and_access_scope_maps_to_glimra(self):
         serializer = EmailAuthSerializer(data={
             'email': 'aaron@example.com',
             'create': True,
@@ -124,6 +124,57 @@ class AccessScopeMappingTests(APITestCase):
         self.assertEqual(user.country, 'fi')
         self.assertEqual(user.access_scope, 'juhlapesu')
 
+    def test_glimra_access_scope_maps_to_sweden(self):
+        serializer = EmailAuthSerializer(data={
+            'email': 'aaron@example.com',
+            'access_scope': 'glimra',
+            'create': True,
+        })
+        self.assertEqual(serializer.is_valid(), True)
+
+        user = serializer.validated_data['user']
+        self.assertEqual(user.country, 'se')
+        self.assertEqual(user.access_scope, 'glimra')
+        self.assertEqual(serializer.validated_data['country'], 'se')
+        self.assertEqual(serializer.validated_data['access_scope'], 'glimra')
+
+    def test_juhlapesu_access_scope_maps_to_finland(self):
+        serializer = EmailAuthSerializer(data={
+            'email': 'aaron@example.com',
+            'access_scope': 'juhlapesu',
+            'create': True,
+        })
+        self.assertEqual(serializer.is_valid(), True)
+
+        user = serializer.validated_data['user']
+        self.assertEqual(user.country, 'fi')
+        self.assertEqual(user.access_scope, 'juhlapesu')
+        self.assertEqual(serializer.validated_data['country'], 'fi')
+        self.assertEqual(serializer.validated_data['access_scope'], 'juhlapesu')
+
+    def test_matching_country_and_access_scope_are_accepted(self):
+        serializer = EmailAuthSerializer(data={
+            'email': 'aaron@example.com',
+            'country': 'fi',
+            'access_scope': 'juhlapesu',
+            'create': True,
+        })
+        self.assertEqual(serializer.is_valid(), True)
+
+        user = serializer.validated_data['user']
+        self.assertEqual(user.country, 'fi')
+        self.assertEqual(user.access_scope, 'juhlapesu')
+
+    def test_mismatched_country_and_access_scope_are_rejected(self):
+        serializer = EmailAuthSerializer(data={
+            'email': 'aaron@example.com',
+            'country': 'se',
+            'access_scope': 'juhlapesu',
+            'create': True,
+        })
+        self.assertEqual(serializer.is_valid(), False)
+        self.assertIn('country', serializer.errors)
+
     def test_unsupported_country_is_rejected(self):
         serializer = EmailAuthSerializer(data={
             'email': 'aaron@example.com',
@@ -132,6 +183,15 @@ class AccessScopeMappingTests(APITestCase):
         })
         self.assertEqual(serializer.is_valid(), False)
         self.assertIn('country', serializer.errors)
+
+    def test_unsupported_access_scope_is_rejected(self):
+        serializer = EmailAuthSerializer(data={
+            'email': 'aaron@example.com',
+            'access_scope': 'unknown',
+            'create': True,
+        })
+        self.assertEqual(serializer.is_valid(), False)
+        self.assertIn('access_scope', serializer.errors)
 
     def test_same_email_can_exist_in_different_access_scopes(self):
         email = 'aaron@example.com'
@@ -145,6 +205,19 @@ class AccessScopeMappingTests(APITestCase):
         self.assertEqual(fi_serializer.is_valid(), True)
         self.assertEqual(se_serializer.validated_data['user'], glimra_user)
         self.assertEqual(fi_serializer.validated_data['user'], juhlapesu_user)
+
+    def test_same_email_can_be_selected_by_explicit_access_scope(self):
+        email = 'aaron@example.com'
+        glimra_user = User.objects.create(email=email, country='se', access_scope='glimra')
+        juhlapesu_user = User.objects.create(email=email, country='fi', access_scope='juhlapesu')
+
+        glimra_serializer = EmailAuthSerializer(data={'email': email, 'access_scope': 'glimra'})
+        juhlapesu_serializer = EmailAuthSerializer(data={'email': email, 'access_scope': 'juhlapesu'})
+
+        self.assertEqual(glimra_serializer.is_valid(), True)
+        self.assertEqual(juhlapesu_serializer.is_valid(), True)
+        self.assertEqual(glimra_serializer.validated_data['user'], glimra_user)
+        self.assertEqual(juhlapesu_serializer.validated_data['user'], juhlapesu_user)
 
     def test_existing_email_registration_is_rejected_in_same_access_scope(self):
         email = 'aaron@example.com'
@@ -172,6 +245,19 @@ class AccessScopeMappingTests(APITestCase):
         self.assertEqual(fi_serializer.is_valid(), True)
         self.assertEqual(se_serializer.validated_data['user'], glimra_user)
         self.assertEqual(fi_serializer.validated_data['user'], juhlapesu_user)
+
+    def test_same_mobile_can_be_selected_by_explicit_access_scope(self):
+        mobile = '+15551234567'
+        glimra_user = User.objects.create(mobile=mobile, country='se', access_scope='glimra')
+        juhlapesu_user = User.objects.create(mobile=mobile, country='fi', access_scope='juhlapesu')
+
+        glimra_serializer = MobileAuthSerializer(data={'mobile': mobile, 'access_scope': 'glimra'})
+        juhlapesu_serializer = MobileAuthSerializer(data={'mobile': mobile, 'access_scope': 'juhlapesu'})
+
+        self.assertEqual(glimra_serializer.is_valid(), True)
+        self.assertEqual(juhlapesu_serializer.is_valid(), True)
+        self.assertEqual(glimra_serializer.validated_data['user'], glimra_user)
+        self.assertEqual(juhlapesu_serializer.validated_data['user'], juhlapesu_user)
 
     def test_existing_mobile_registration_is_rejected_in_same_access_scope(self):
         mobile = '+15551234567'

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -124,42 +124,6 @@ class AccessScopeMappingTests(APITestCase):
         self.assertEqual(user.country, 'fi')
         self.assertEqual(user.access_scope, 'juhlapesu')
 
-    def test_existing_email_with_null_access_scope_is_found_by_country(self):
-        email = 'aaron@example.com'
-        existing_user = User.objects.create(email=email, country='fi', access_scope=None)
-
-        serializer = EmailAuthSerializer(data={'email': email, 'country': 'fi'})
-
-        self.assertEqual(serializer.is_valid(), True)
-        self.assertEqual(serializer.validated_data['user'], existing_user)
-        self.assertIsNone(serializer.validated_data['user'].access_scope)
-        self.assertEqual(serializer.validated_data['access_scope'], 'juhlapesu')
-
-    def test_existing_mobile_with_null_access_scope_is_found_by_country(self):
-        mobile = '+15551234567'
-        existing_user = User.objects.create(mobile=mobile, country='se', access_scope=None)
-
-        serializer = MobileAuthSerializer(data={'mobile': mobile, 'country': 'se'})
-
-        self.assertEqual(serializer.is_valid(), True)
-        self.assertEqual(serializer.validated_data['user'], existing_user)
-        self.assertIsNone(serializer.validated_data['user'].access_scope)
-        self.assertEqual(serializer.validated_data['access_scope'], 'glimra')
-
-    def test_create_true_rejects_existing_user_with_null_access_scope(self):
-        email = 'aaron@example.com'
-        User.objects.create(email=email, country='se', access_scope=None)
-
-        serializer = EmailAuthSerializer(data={
-            'email': email,
-            'country': 'se',
-            'create': True,
-        })
-
-        self.assertEqual(serializer.is_valid(), False)
-        self.assertIn('non_field_errors', serializer.errors)
-        self.assertEqual(User.objects.count(), 1)
-
     def test_unsupported_country_is_rejected(self):
         serializer = EmailAuthSerializer(data={
             'email': 'aaron@example.com',
@@ -182,7 +146,7 @@ class AccessScopeMappingTests(APITestCase):
         self.assertEqual(se_serializer.validated_data['user'], glimra_user)
         self.assertEqual(fi_serializer.validated_data['user'], juhlapesu_user)
 
-    def test_existing_email_registration_is_rejected_in_same_country(self):
+    def test_existing_email_registration_is_rejected_in_same_access_scope(self):
         email = 'aaron@example.com'
         User.objects.create(email=email, country='se', access_scope='glimra', digilets=1)
 
@@ -209,7 +173,7 @@ class AccessScopeMappingTests(APITestCase):
         self.assertEqual(se_serializer.validated_data['user'], glimra_user)
         self.assertEqual(fi_serializer.validated_data['user'], juhlapesu_user)
 
-    def test_existing_mobile_registration_is_rejected_in_same_country(self):
+    def test_existing_mobile_registration_is_rejected_in_same_access_scope(self):
         mobile = '+15551234567'
         User.objects.create(mobile=mobile, country='se', access_scope='glimra', digilets=1)
 
@@ -221,84 +185,6 @@ class AccessScopeMappingTests(APITestCase):
 
         self.assertEqual(serializer.is_valid(), False)
         self.assertIn('non_field_errors', serializer.errors)
-        self.assertEqual(User.objects.count(), 1)
-
-
-class NullAccessScopeLoginCallbackTokenTests(APITestCase):
-
-    def tearDown(self):
-        api_settings.PASSWORDLESS_TEST_SUPPRESSION = DEFAULTS['PASSWORDLESS_TEST_SUPPRESSION']
-        api_settings.PASSWORDLESS_AUTH_TYPES = DEFAULTS['PASSWORDLESS_AUTH_TYPES']
-        api_settings.PASSWORDLESS_EMAIL_NOREPLY_ADDRESS = DEFAULTS['PASSWORDLESS_EMAIL_NOREPLY_ADDRESS']
-        api_settings.PASSWORDLESS_EMAIL_NOREPLY_ADDRESS_FI = DEFAULTS['PASSWORDLESS_EMAIL_NOREPLY_ADDRESS_FI']
-        api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER = DEFAULTS['PASSWORDLESS_MOBILE_NOREPLY_NUMBER']
-        api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER_FI = DEFAULTS['PASSWORDLESS_MOBILE_NOREPLY_NUMBER_FI']
-
-    def test_existing_se_email_with_null_access_scope_can_request_token(self):
-        api_settings.PASSWORDLESS_AUTH_TYPES = ['EMAIL']
-        api_settings.PASSWORDLESS_EMAIL_NOREPLY_ADDRESS = 'noreply@example.com'
-        user = User.objects.create(email='se@example.com', country='se', access_scope=None)
-
-        response = self.client.post('/auth/email/', {'email': user.email, 'country': 'se'})
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(CallbackToken.objects.filter(user=user, is_active=True).count(), 1)
-        user.refresh_from_db()
-        self.assertIsNone(user.access_scope)
-
-    def test_existing_fi_email_with_null_access_scope_can_request_token(self):
-        api_settings.PASSWORDLESS_AUTH_TYPES = ['EMAIL']
-        api_settings.PASSWORDLESS_EMAIL_NOREPLY_ADDRESS = 'noreply@example.com'
-        api_settings.PASSWORDLESS_EMAIL_NOREPLY_ADDRESS_FI = 'noreply-fi@example.com'
-        user = User.objects.create(email='fi@example.com', country='fi', access_scope=None)
-
-        response = self.client.post('/auth/email/', {'email': user.email, 'country': 'fi'})
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(CallbackToken.objects.filter(user=user, is_active=True).count(), 1)
-        user.refresh_from_db()
-        self.assertIsNone(user.access_scope)
-
-    def test_existing_se_mobile_with_null_access_scope_can_request_token(self):
-        api_settings.PASSWORDLESS_TEST_SUPPRESSION = True
-        api_settings.PASSWORDLESS_AUTH_TYPES = ['MOBILE']
-        api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER = '+15550000000'
-        user = User.objects.create(mobile='+15551234567', country='se', access_scope=None)
-
-        response = self.client.post('/auth/mobile/', {'mobile': user.mobile, 'country': 'se'})
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(CallbackToken.objects.filter(user=user, is_active=True).count(), 1)
-        user.refresh_from_db()
-        self.assertIsNone(user.access_scope)
-
-    def test_existing_fi_mobile_with_null_access_scope_can_request_token(self):
-        api_settings.PASSWORDLESS_TEST_SUPPRESSION = True
-        api_settings.PASSWORDLESS_AUTH_TYPES = ['MOBILE']
-        api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER_FI = '+358500000000'
-        user = User.objects.create(mobile='+15557654321', country='fi', access_scope=None)
-
-        response = self.client.post('/auth/mobile/', {'mobile': user.mobile, 'country': 'fi'})
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(CallbackToken.objects.filter(user=user, is_active=True).count(), 1)
-        user.refresh_from_db()
-        self.assertIsNone(user.access_scope)
-
-    def test_existing_mobile_create_request_is_rejected_without_sending_token(self):
-        api_settings.PASSWORDLESS_TEST_SUPPRESSION = True
-        api_settings.PASSWORDLESS_AUTH_TYPES = ['MOBILE']
-        api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER = '+15550000000'
-        user = User.objects.create(mobile='+15559876543', country='se', access_scope=None)
-
-        response = self.client.post('/auth/mobile/', {
-            'mobile': user.mobile,
-            'country': 'se',
-            'create': True,
-        })
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(CallbackToken.objects.filter(user=user, is_active=True).count(), 0)
         self.assertEqual(User.objects.count(), 1)
 
 


### PR DESCRIPTION
- Added access_scope as an accepted auth API request field for email and mobile login/signup.
- Kept country backwards-compatible: if access_scope is absent, it is derived from country; if both are absent, defaults to se/glimra.
- Made access_scope the primary mapping source and derive country from it when only scope is provided.
- Reject requests where both country and access_scope are provided but do not match.
- Updated user lookup/creation to continue segmenting aliases by resolved access_scope.
- Added tests for explicit scope handling, default behavior, mismatch validation, and email/mobile lookup across scopes.